### PR TITLE
Add a new alias `then` to `Kernel#yield_self`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Add a new alias `then` to `Kernel#yield_self`.
+
 ## 1.0.0
 
 * This release has not changed. It is probably the last release.

--- a/ext/backport_yield_self/backport_yield_self.c
+++ b/ext/backport_yield_self/backport_yield_self.c
@@ -31,11 +31,12 @@ rb_obj_hide(VALUE obj)
 /*
  *  call-seq:
  *     obj.yield_self {|x| block }    -> an_object
+ *     obj.then {|x| block }          -> an_object
  *
  *  Yields self to the block and returns the result of the block.
  *
- *     "my string".yield_self {|s| s.upcase }   #=> "MY STRING"
  *     3.next.yield_self {|x| x**x }.to_s       #=> "256"
+ *     "my string".yield_self {|s| s.upcase }   #=> "MY STRING"
  *
  */
 
@@ -55,4 +56,5 @@ Init_backport_yield_self(void)
     rb_mKernel = rb_define_module("Kernel");
 
     rb_define_method(rb_mKernel, "yield_self", rb_obj_yield_self, 0);
+    rb_define_method(rb_mKernel, "then", rb_obj_yield_self, 0);
 }

--- a/spec/backport_yield_self_spec.rb
+++ b/spec/backport_yield_self_spec.rb
@@ -8,5 +8,6 @@ describe Kernel do
     specify { expect(object.yield_self.size).to eq 1 }
     specify { expect('my string'.yield_self {|s| s.upcase }).to eq 'MY STRING' }
     specify { expect(3.next.yield_self {|x| x**x }.to_s).to eq '256' }
+    specify { expect(object.then { 42 }).to eq 42 }
   end
 end


### PR DESCRIPTION
Follow up of https://github.com/ruby/ruby/commit/d53ee008911b5c3b22cff1566a9ef7e7d4cbe183

There is a discussion about the name of `then` method.
This PR will not be merged until Ruby 2.6.0 is final released.